### PR TITLE
Adds gpt-2 compatible tensorflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,7 @@
-FROM jupyter/tensorflow-notebook
-RUN pip install gpt-2-simple
+FROM jupyter/scipy-notebook
+
+RUN pip install --quiet \
+    'tensorflow==1.15' gpt-2-simple && \
+    conda clean --all -f -y && \
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER


### PR DESCRIPTION
I made some tweaks to our dockerfile to support `gpt-2`. In order to get tensorflow 1.15 installed I tweaked the base jupyter notebook image we were using. You can see it [here](https://github.com/jupyter/docker-stacks/blob/master/tensorflow-notebook/Dockerfile). While this seems to build and I can make calls to the `gpt-2-simple` library I don't know that we will be able to do local development with `gpt-2-simple`. 

I ran into the following error when running a shell within the jupyter notebook and executing `python gpt-2.py`. I think this is likely an indicator of the size of the VM I have allocated for docker but I am not certain. It may be that the suggestion that `gpt-2-simple` makes of using colab or other cloud based server resource might be that it is a very resource intensive operation and it will be difficult to run locally. 

![image](https://user-images.githubusercontent.com/16239428/71328114-73042f00-24c6-11ea-9f19-279118b1afe7.png)

Has anyone had success running it locally? @ddong63 have you been working out of colab for your changes? Perhaps we should just add directions of how to run our stuff on colab or similar? 